### PR TITLE
Add --body-file / --chunk-file flags for body-text CLI commands (closes #2)

### DIFF
--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1227,9 +1227,10 @@ The system maintains an in-memory cache of parsed tickets, keyed by ticket ID. E
 
 | Command | Key Arguments |
 |---------|--------------|
-| `create-ticket` | `--ticket-type --title --hive [--description --parent --children --up-deps --down-deps --tags --status --egg]` |
+| `create-ticket` | `--ticket-type --title --hive [--body \| --body-file --parent --children --up-deps --down-deps --tags --status --egg]` |
 | `show-ticket` | `ID [ID ...]` |
-| `update-ticket` | `ID [--title --description --status --tags --up-deps --down-deps --egg --add-tags --remove-tags --hive]` |
+| `update-ticket` | `--ids ID [ID ...] [--title --body \| --body-file --status --tags --up-deps --down-deps --egg --add-tags --remove-tags --hive]` |
+| `append-ticket-body` | `--ticket-id (--chunk \| --chunk-file) [--hive]` |
 | `delete-ticket` | `ID [ID ...] [--hive]` |
 | `get-types` | (none) |
 | `set-types` | `--scope [--hive] [--child-tiers JSON] [--unset]` |
@@ -1793,11 +1794,36 @@ commands:
     serve               Start the MCP server
 ```
 
+### `bees append-ticket-body`
+
+```
+usage: bees append-ticket-body --ticket-id ID (--chunk TEXT | --chunk-file PATH)
+                               [--hive NAME]
+
+Append a chunk to an existing ticket's body. Each call concatenates --chunk onto
+the end of the existing body with no separator. Use this whenever the full body
+would exceed 10000 characters on create-ticket / update-ticket: create the ticket
+with the first 10000-character chunk, then call append-ticket-body repeatedly
+with subsequent chunks of up to 10000 characters each. Empty chunks are accepted
+as no-ops.
+
+  --ticket-id ID        ID of the existing ticket whose body will be appended to
+                        (e.g. b.amx, t1.nha).
+  --chunk TEXT          Text to append to the ticket body (required: one of
+                        --chunk or --chunk-file). Must be 10000 characters or
+                        fewer; pass an empty string for a no-op.
+  --chunk-file PATH     Read the chunk text from a UTF-8 file (use '-' for
+                        stdin); same 10000-character per-chunk cap as --chunk.
+  --hive NAME           Hive name for O(1) ticket lookup (optional).
+```
+
+Note: `--chunk` and `--chunk-file` are mutually exclusive (exactly one is required); pass `--chunk-file -` to read the chunk from stdin.
+
 ### `bees create-ticket`
 
 ```
 usage: bees create-ticket --ticket-type TYPE --title TITLE --hive HIVE
-                          [--description TEXT] [--parent ID]
+                          [--body BODY | --body-file PATH] [--parent ID]
                           [--children JSON] [--up-deps JSON] [--down-deps JSON]
                           [--tags JSON] [--status STATUS] [--egg JSON]
 
@@ -1805,7 +1831,14 @@ usage: bees create-ticket --ticket-type TYPE --title TITLE --hive HIVE
                         or friendly name. Run get-types to see configured tiers.
   --title TITLE         Ticket title
   --hive HIVE           Hive to create the ticket in
-  --description TEXT    Ticket description (markdown)
+  --body BODY           Ticket body (markdown). Capped at 10000 characters; for
+                        larger bodies, create the ticket with the first
+                        10000-character chunk and use 'bees append-ticket-body'
+                        to write the rest in chunks of up to 10000 characters
+                        each.
+  --body-file PATH      Read body from a UTF-8 file (use '-' for stdin); same
+                        10000 character cap as --body, with oversized input
+                        pointed at 'bees append-ticket-body'.
   --parent ID           Parent ticket ID. Required for child-tier tickets.
   --children JSON       JSON array of child IDs to link
   --up-deps JSON        JSON array of ticket IDs that must be resolved BEFORE this one
@@ -1814,6 +1847,8 @@ usage: bees create-ticket --ticket-type TYPE --title TITLE --hive HIVE
   --status STATUS       Ticket status
   --egg JSON            Any JSON value. Only supported on bee tickets.
 ```
+
+Note: `--body` and `--body-file` are mutually exclusive; pass `--body-file -` to read the body from stdin.
 
 ### `bees show-ticket`
 
@@ -1826,8 +1861,8 @@ usage: bees show-ticket --ids ID [ID ...]
 ### `bees update-ticket`
 
 ```
-usage: bees update-ticket --ticket-id ID [--title TITLE]
-                          [--description TEXT] [--status STATUS]
+usage: bees update-ticket --ids ID [ID ...] [--title TITLE]
+                          [--body BODY | --body-file PATH] [--status STATUS]
                           [--tags JSON] [--up-deps JSON] [--down-deps JSON]
                           [--egg JSON] [--add-tags JSON] [--remove-tags JSON]
                           [--hive HIVE]
@@ -1835,9 +1870,15 @@ usage: bees update-ticket --ticket-id ID [--title TITLE]
 Update an existing ticket's fields. Only provided flags are changed; omitted
 flags are left as-is. Pass null to JSON fields to clear them (e.g. --tags null).
 
-  --ticket-id ID        Ticket ID to update
+  --ids ID [ID ...]     One or more ticket IDs to update
   --title TITLE         New title
-  --description TEXT    New description (markdown)
+  --body BODY           New body (markdown). Capped at 10000 characters; for
+                        larger bodies, set the body to the first 10000-character
+                        chunk and use 'bees append-ticket-body' to write the
+                        rest in chunks of up to 10000 characters each.
+  --body-file PATH      Read new body from a UTF-8 file (use '-' for stdin);
+                        same 10000 character cap as --body, with oversized input
+                        pointed at 'bees append-ticket-body'.
   --status STATUS       New status
   --tags JSON           Full replacement tag list as JSON array (null to clear)
   --up-deps JSON        Full replacement list of blocking ticket IDs (null to clear)
@@ -1847,6 +1888,8 @@ flags are left as-is. Pass null to JSON fields to clear them (e.g. --tags null).
   --remove-tags JSON    JSON array of tags to remove
   --hive HIVE           Hive name for faster lookup (optional)
 ```
+
+Note: `--body` and `--body-file` are mutually exclusive; pass `--body-file -` to read the body from stdin.
 
 ### `bees delete-ticket`
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -368,11 +368,14 @@ Child IDs embed the parent's short ID as a prefix (hierarchical): bee `b.amx` â†
 ```bash
 bees create-ticket --type bee --title "Bug fix" --hive backend
 bees create-ticket --type bee --title "Long writeup" --hive backend --body "stub - see appended chunks"
+bees create-ticket --type bee --title "From file" --hive backend --body-file ./writeup.md
 bees show-ticket b.amx t1.amx.12
 bees update-ticket --ids b.amx --status worker --tags '["urgent"]'
 bees update-ticket --ids b.amx --add-tags '["reviewed"]' --remove-tags '["urgent"]'
 bees update-ticket --ids b.amx b.x4f --status worker
+bees update-ticket --ids b.amx --body-file -    # read new body from stdin
 bees append-ticket-body --ticket-id b.amx --chunk "more body text up to 10000 characters"
+bees append-ticket-body --ticket-id b.amx --chunk-file ./next-chunk.md
 bees delete-ticket b.amx
 bees get-types
 bees set-types --scope global --tiers '{"t1":["Epic","Epics"]}'
@@ -388,6 +391,8 @@ bees set-status-values --scope=global --unset
 `show-ticket` and `delete-ticket` accept multiple IDs. `update-ticket` accepts multiple IDs when using `--status`, `--add-tags`, or `--remove-tags` (batch updates do not support `--title`, `--body`, or `--egg`).
 
 `create-ticket --body` and `update-ticket --body` cap the inline body at 10000 characters; oversized values are rejected up front. To write a longer body, create or update the ticket with a short stub body and then call `append-ticket-body` repeatedly with chunks of up to 10000 characters each. Chunks are concatenated to the end of the body in call order with no separator. An empty `--chunk` is a success no-op, so the subcommand is safe inside idempotent retry loops.
+
+`--body`/`--body-file` and `--chunk`/`--chunk-file` are mutually exclusive; the file flags read content from the named path (or stdin when the path is `-`), and the same 10000-character cap applies regardless of input source.
 
 ## Query Operations
 

--- a/docs/advanced-usage.md
+++ b/docs/advanced-usage.md
@@ -368,7 +368,7 @@ Child IDs embed the parent's short ID as a prefix (hierarchical): bee `b.amx` â†
 ```bash
 bees create-ticket --type bee --title "Bug fix" --hive backend
 bees create-ticket --type bee --title "Long writeup" --hive backend --body "stub - see appended chunks"
-bees create-ticket --type bee --title "From file" --hive backend --body-file ./writeup.md
+bees create-ticket --ticket-type bee --title "From file" --hive backend --body-file ./writeup.md
 bees show-ticket b.amx t1.amx.12
 bees update-ticket --ids b.amx --status worker --tags '["urgent"]'
 bees update-ticket --ids b.amx --add-tags '["reviewed"]' --remove-tags '["urgent"]'

--- a/src/cli.py
+++ b/src/cli.py
@@ -234,8 +234,11 @@ def handle_update_ticket(args):
     if _guard_queen_write_cli(root):
         return
 
+    if args.body_file is not None:
+        args.body = _read_body_file_arg("--body-file", args.body_file)
+
     if args.body is not _UNSET and args.body is not None:
-        _reject_oversized_body_cli("--body", args.body)
+        _reject_oversized_body_cli("--body-file" if args.body_file else "--body", args.body)
 
     # Build kwargs: only pass fields that were explicitly provided (not _UNSET)
     ticket_ids = args.ids[0] if len(args.ids) == 1 else args.ids
@@ -812,7 +815,9 @@ def build_parser():
     )
     p_update.add_argument("--ids", required=True, nargs="+", metavar="ID", help="One or more ticket IDs to update")
     p_update.add_argument("--title", default=_UNSET, help="New title")
-    p_update.add_argument("--body", default=_UNSET, help="New body (markdown). Capped at 10000 characters; for larger bodies, set the body to the first 10000-character chunk and use 'bees append-ticket-body' to write the rest in chunks of up to 10000 characters each.")  # noqa: E501
+    p_update_body = p_update.add_mutually_exclusive_group()
+    p_update_body.add_argument("--body", default=_UNSET, help="New body (markdown). Capped at 10000 characters; for larger bodies, set the body to the first 10000-character chunk and use 'bees append-ticket-body' to write the rest in chunks of up to 10000 characters each. Alternative: pass --body-file PATH when shell substitution is awkward.")  # noqa: E501
+    p_update_body.add_argument("--body-file", dest="body_file", default=None, metavar="PATH", help="Read new body from a UTF-8 file (use '-' for stdin); same 10000 character cap as --body, with oversized input pointed at 'bees append-ticket-body'.")  # noqa: E501
     p_update.add_argument("--status", default=_UNSET, help="New status")
     p_update.add_argument("--tags", default=_UNSET, dest="tags", metavar="JSON", help="Full replacement tag list as JSON array (null to clear)")  # noqa: E501
     p_update.add_argument("--up-deps", default=_UNSET, dest="up_deps", metavar="JSON", help="Full replacement list of ticket IDs that must be resolved BEFORE this one (null to clear)")  # noqa: E501

--- a/src/cli.py
+++ b/src/cli.py
@@ -195,8 +195,10 @@ def handle_create_ticket(args):
     root = get_repo_root_from_path(Path.cwd())
     if _guard_queen_write_cli(root):
         return
+    if args.body_file is not None:
+        args.body = _read_body_file_arg("--body-file", args.body_file)
     if args.body is not None:
-        _reject_oversized_body_cli("--body", args.body)
+        _reject_oversized_body_cli("--body-file" if args.body_file else "--body", args.body)
     result = _run_in_repo(
         _create_ticket(
             ticket_type=args.ticket_type,
@@ -781,7 +783,9 @@ def build_parser():
     p_create.add_argument("--ticket-type", required=True, dest="ticket_type", help='Ticket type: "bee" for top-level, or child tier by ID ("t1", "t2") or friendly name. Run get-types to see configured tiers.')  # noqa: E501
     p_create.add_argument("--title", required=True, help="Ticket title")
     p_create.add_argument("--hive", required=True, help="Hive to create the ticket in. Run list-hives to see available hives.")  # noqa: E501
-    p_create.add_argument("--body", default=None, help="Ticket body (markdown). Capped at 10000 characters; for larger bodies, create the ticket with the first 10000-character chunk and use 'bees append-ticket-body' to write the rest in chunks of up to 10000 characters each.")  # noqa: E501
+    p_create_body = p_create.add_mutually_exclusive_group()
+    p_create_body.add_argument("--body", default=None, help="Ticket body (markdown). Capped at 10000 characters; for larger bodies, create the ticket with the first 10000-character chunk and use 'bees append-ticket-body' to write the rest in chunks of up to 10000 characters each. Alternative: pass --body-file PATH when shell substitution is awkward.")  # noqa: E501
+    p_create_body.add_argument("--body-file", dest="body_file", default=None, metavar="PATH", help="Read body from a UTF-8 file (use '-' for stdin); same 10000 character cap as --body, with oversized input pointed at 'bees append-ticket-body'.")  # noqa: E501
     p_create.add_argument("--parent", default=None, help="Parent ticket ID. Required for child-tier tickets; omit for bees. Parent's children field is updated automatically.")  # noqa: E501
     p_create.add_argument("--children", default=None, metavar="JSON", help="JSON array of child IDs to link. Bidirectional — child tickets' parent field is set automatically.")  # noqa: E501
     p_create.add_argument("--up-deps", default=None, dest="up_deps", metavar="JSON", help="JSON array of ticket IDs that must be resolved BEFORE this one.")  # noqa: E501

--- a/src/cli.py
+++ b/src/cli.py
@@ -291,7 +291,9 @@ def handle_append_ticket_body(args):
     root = get_repo_root_from_path(Path.cwd())
     if _guard_queen_write_cli(root):
         return
-    _reject_oversized_body_cli("--chunk", args.chunk)
+    if args.chunk_file is not None:
+        args.chunk = _read_body_file_arg("--chunk-file", args.chunk_file)
+    _reject_oversized_body_cli("--chunk-file" if args.chunk_file else "--chunk", args.chunk)
     result = _run_in_repo(
         _append_ticket_body(
             ticket_id=args.ticket_id,
@@ -860,11 +862,18 @@ def build_parser():
         metavar="ID",
         help="ID of the existing ticket whose body will be appended to (e.g. b.amx, t1.nha).",
     )
-    p_append_body.add_argument(
+    p_append_chunk = p_append_body.add_mutually_exclusive_group(required=True)
+    p_append_chunk.add_argument(
         "--chunk",
-        required=True,
         metavar="TEXT",
-        help="Text to append to the ticket body. Must be 10000 characters or fewer; pass an empty string for a no-op. To write bodies larger than 10000 characters, call this subcommand repeatedly with successive chunks.",  # noqa: E501
+        help="Text to append to the ticket body (required: one of --chunk or --chunk-file). Must be 10000 characters or fewer; pass an empty string for a no-op. To write bodies larger than 10000 characters, call this subcommand repeatedly with successive chunks. Alternative: pass --chunk-file PATH when shell substitution is awkward.",  # noqa: E501
+    )
+    p_append_chunk.add_argument(
+        "--chunk-file",
+        dest="chunk_file",
+        default=None,
+        metavar="PATH",
+        help="Read the chunk text from a UTF-8 file (use '-' for stdin); same 10000-character per-chunk cap as --chunk. Alternative to --chunk for harnesses where shell substitution / quoting is awkward.",  # noqa: E501
     )
     p_append_body.add_argument(
         "--hive",

--- a/src/cli.py
+++ b/src/cli.py
@@ -198,7 +198,7 @@ def handle_create_ticket(args):
     if args.body_file is not None:
         args.body = _read_body_file_arg("--body-file", args.body_file)
     if args.body is not None:
-        _reject_oversized_body_cli("--body-file" if args.body_file else "--body", args.body)
+        _reject_oversized_body_cli("--body-file" if args.body_file is not None else "--body", args.body)
     result = _run_in_repo(
         _create_ticket(
             ticket_type=args.ticket_type,
@@ -238,7 +238,7 @@ def handle_update_ticket(args):
         args.body = _read_body_file_arg("--body-file", args.body_file)
 
     if args.body is not _UNSET and args.body is not None:
-        _reject_oversized_body_cli("--body-file" if args.body_file else "--body", args.body)
+        _reject_oversized_body_cli("--body-file" if args.body_file is not None else "--body", args.body)
 
     # Build kwargs: only pass fields that were explicitly provided (not _UNSET)
     ticket_ids = args.ids[0] if len(args.ids) == 1 else args.ids
@@ -293,7 +293,7 @@ def handle_append_ticket_body(args):
         return
     if args.chunk_file is not None:
         args.chunk = _read_body_file_arg("--chunk-file", args.chunk_file)
-    _reject_oversized_body_cli("--chunk-file" if args.chunk_file else "--chunk", args.chunk)
+    _reject_oversized_body_cli("--chunk-file" if args.chunk_file is not None else "--chunk", args.chunk)
     result = _run_in_repo(
         _append_ticket_body(
             ticket_id=args.ticket_id,

--- a/src/cli.py
+++ b/src/cli.py
@@ -120,6 +120,57 @@ def _reject_oversized_body_cli(arg_name: str, value: str) -> None:
     sys.exit(1)
 
 
+def _read_body_file_arg(arg_name: str, path: str) -> str:
+    """Read body text for a ``--body-file`` / ``--chunk-file`` CLI flag.
+
+    The flag eliminates ``$(cat ...)`` shell substitution, which agentic
+    harnesses (Claude Code) otherwise prompt on. Future call sites:
+    ``handle_create_ticket`` (Task 2 of Epic 1), ``handle_update_ticket``
+    (Epic 2), and ``handle_append_ticket_body`` (Epic 3).
+
+    Behavior:
+      - ``path == "-"``: read all of ``sys.stdin`` as UTF-8 and return it.
+      - File-not-found, OS/permission error, and UTF-8 decode error each
+        write a single-line ``Error:`` message to stderr that names
+        ``arg_name`` and ``path``, then exit with status 1.
+      - Otherwise return the decoded UTF-8 contents verbatim. No length
+        check, trimming, or normalization is performed; callers continue
+        to invoke ``_reject_oversized_body_cli`` on the return value.
+    """
+    if path == "-":
+        try:
+            return sys.stdin.read()
+        except UnicodeDecodeError as exc:
+            print(
+                f"Error: {arg_name} could not decode stdin as UTF-8 ({path}): {exc}",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+    try:
+        with open(path, "rb") as fh:
+            data = fh.read()
+    except FileNotFoundError:
+        print(
+            f"Error: {arg_name} file not found: {path}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    except OSError as exc:
+        print(
+            f"Error: {arg_name} could not read {path}: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    try:
+        return data.decode("utf-8")
+    except UnicodeDecodeError as exc:
+        print(
+            f"Error: {arg_name} could not decode {path} as UTF-8: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
 def _configure_file_logging() -> Path:
     """Redirect root logger to ~/.bees/mcp.log (file-only). Returns log path."""
     log_path = Path.home() / ".bees" / "mcp.log"

--- a/tests/test_cli_append_ticket_body.py
+++ b/tests/test_cli_append_ticket_body.py
@@ -347,6 +347,19 @@ def test_append_ticket_body_missing_required_chunk_or_chunk_file(cli_runner):
     assert result["status"] == "error"
 
 
+def test_append_ticket_body_help_text_mentions_chunk_file_stdin_and_cap(cli_runner):
+    """`bees append-ticket-body --help` advertises --chunk-file with stdin and the cap (AC #8)."""
+    import re
+
+    stdout, exit_code = cli_runner(["append-ticket-body", "--help"])
+    assert exit_code == 0
+    rejoined = re.sub(r"-\s*\n\s*", "-", stdout)
+    flat = " ".join(rejoined.split())
+    assert "--chunk-file" in flat
+    assert "'-'" in flat
+    assert "10000" in flat
+
+
 # ---------------------------------------------------------------------------
 # Rejection / error paths — Epic 3 / t1.jsz.nb (--chunk-file)
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_append_ticket_body.py
+++ b/tests/test_cli_append_ticket_body.py
@@ -1,12 +1,27 @@
 """Integration tests for the bees ``append-ticket-body`` CLI subcommand.
 
-Covers Epic 4 of the chunked-ticket-body-API plan (Bee b.87r):
-- Happy path append of a small chunk.
-- At-cap (10000 char) chunk succeeds.
-- Oversized (10001 char) chunk is rejected by ``_reject_oversized_body_cli``
-  before any ticket I/O. Stderr names the cap and the subcommand. The
-  ticket file on disk is byte-identical to its pre-call snapshot.
-- Empty chunk is a success no-op.
+Covers Epic 4 of the chunked-ticket-body-API plan (Bee b.87r) and Epic 3 /
+Task 1 (``t1.jsz.nb``) of Bee ``b.jsz``, which adds ``--chunk-file PATH``
+as a sibling of ``--chunk`` inside a required mutually-exclusive group.
+
+- Happy path append of a small inline chunk (``--chunk``).
+- Happy path append from a UTF-8 file (``--chunk-file PATH``) and from
+  stdin (``--chunk-file -``).
+- At-cap (10000 char) chunk and at-cap file both succeed.
+- Oversized (10001 char) chunk and oversized file are rejected by
+  ``_reject_oversized_body_cli`` before any ticket I/O. Stderr names the
+  cap, the subcommand, and the originating flag (``--chunk`` for inline,
+  ``--chunk-file`` for file). The ticket file on disk is byte-identical
+  to its pre-call snapshot.
+- Empty inline chunk and empty ``--chunk-file`` are both success no-ops:
+  ticket bytes are unchanged. NOTE: append + empty = concatenation
+  (no-op) deliberately diverges from ``update-ticket --body-file`` whose
+  empty-file case overwrites the body to empty.
+- Mutex errors: passing both ``--chunk`` and ``--chunk-file``, or
+  passing neither, exits with argparse code 2 and leaves the ticket
+  byte-identical.
+- ``--chunk-file`` missing-file and UTF-8-decode errors are rejected
+  with diagnostic stderr and the ticket byte-identical.
 - Bogus ``--ticket-id`` returns a structured ``ticket_not_found`` error.
 - Direct unit test of ``_reject_oversized_body_cli``.
 
@@ -16,12 +31,14 @@ CLI surface without colliding on the same file. It deliberately avoids
 ``tests/test_cli.py``, which has unrelated pre-existing collection errors.
 """
 
+import io
 import json
 
 import pytest
 
 from src.constants import BODY_MAX_LENGTH
 from src.paths import compute_ticket_path
+from tests.helpers import make_body_at_cap, make_body_over_cap
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -69,9 +86,7 @@ def _read_body_via_show(cli_runner, ticket_id: str) -> str:
 def test_append_ticket_body_happy_path(cli_runner, isolated_bees_env):
     ticket_id = _create_bee_with_body(cli_runner, isolated_bees_env, body="hello")
 
-    stdout, exit_code = cli_runner(
-        ["append-ticket-body", "--ticket-id", ticket_id, "--chunk", " world"]
-    )
+    stdout, exit_code = cli_runner(["append-ticket-body", "--ticket-id", ticket_id, "--chunk", " world"])
 
     assert exit_code == 0, f"append failed: {stdout}"
     result = json.loads(stdout)
@@ -87,9 +102,7 @@ def test_append_ticket_body_at_cap(cli_runner, isolated_bees_env):
     ticket_id = _create_bee_with_body(cli_runner, isolated_bees_env, body="")
     chunk = "x" * BODY_MAX_LENGTH
 
-    stdout, exit_code = cli_runner(
-        ["append-ticket-body", "--ticket-id", ticket_id, "--chunk", chunk]
-    )
+    stdout, exit_code = cli_runner(["append-ticket-body", "--ticket-id", ticket_id, "--chunk", chunk])
 
     assert exit_code == 0, f"at-cap append failed: {stdout}"
     result = json.loads(stdout)
@@ -106,9 +119,7 @@ def test_append_ticket_body_empty_chunk_noop(cli_runner, isolated_bees_env):
     path = _ticket_path(isolated_bees_env, ticket_id)
     snapshot = path.read_bytes()
 
-    stdout, exit_code = cli_runner(
-        ["append-ticket-body", "--ticket-id", ticket_id, "--chunk", ""]
-    )
+    stdout, exit_code = cli_runner(["append-ticket-body", "--ticket-id", ticket_id, "--chunk", ""])
 
     assert exit_code == 0, f"empty-chunk append failed: {stdout}"
     result = json.loads(stdout)
@@ -139,6 +150,126 @@ def test_append_ticket_body_with_hive_hint(cli_runner, isolated_bees_env):
 
 
 # ---------------------------------------------------------------------------
+# Happy paths — Epic 3 / t1.jsz.nb (--chunk-file)
+# ---------------------------------------------------------------------------
+
+
+def test_append_ticket_body_chunk_file_happy_path_file(cli_runner, isolated_bees_env, tmp_path):
+    """``--chunk-file <path>`` reads UTF-8 (incl. non-ASCII) and appends it.
+
+    Verifies the wired path: parser dispatches to ``_read_body_file_arg``,
+    the cap check accepts the result, and the persisted body equals the
+    pre-call body concatenated with the file content (no separator).
+    """
+    ticket_id = _create_bee_with_body(cli_runner, isolated_bees_env, body="seed")
+    file_content = " world é"  # non-ASCII codepoint exercises UTF-8 decoding
+    path = tmp_path / "chunk.txt"
+    path.write_text(file_content, encoding="utf-8")
+
+    stdout, exit_code = cli_runner(
+        [
+            "append-ticket-body",
+            "--ticket-id",
+            ticket_id,
+            "--chunk-file",
+            str(path),
+        ]
+    )
+
+    assert exit_code == 0, f"file-append failed: {stdout}"
+    result = json.loads(stdout)
+    assert result["status"] == "success"
+    assert result["appended"] == [ticket_id]
+
+    body = _read_body_via_show(cli_runner, ticket_id)
+    assert body == "seed" + file_content
+
+
+def test_append_ticket_body_chunk_file_happy_path_stdin(cli_runner, isolated_bees_env, monkeypatch):
+    """``--chunk-file -`` reads from sys.stdin via in-process patching.
+
+    ``cli_runner`` invokes ``src.cli.main()`` IN-PROCESS (see
+    ``tests/conftest.py:618-637``); it does NOT spawn a subprocess. Stdin
+    must be patched on the live ``sys`` module — ``subprocess.run(input=...)``
+    would never reach the in-process call.
+    """
+    ticket_id = _create_bee_with_body(cli_runner, isolated_bees_env, body="seed")
+    monkeypatch.setattr("sys.stdin", io.StringIO("from-stdin"))
+
+    stdout, exit_code = cli_runner(
+        [
+            "append-ticket-body",
+            "--ticket-id",
+            ticket_id,
+            "--chunk-file",
+            "-",
+        ]
+    )
+
+    assert exit_code == 0, f"stdin-append failed: {stdout}"
+    result = json.loads(stdout)
+    assert result["status"] == "success"
+
+    body = _read_body_via_show(cli_runner, ticket_id)
+    assert body == "seed" + "from-stdin"
+
+
+def test_append_ticket_body_chunk_file_at_cap(cli_runner, isolated_bees_env, tmp_path):
+    """A file with exactly ``BODY_MAX_LENGTH`` characters appends successfully.
+
+    Mirrors the inline ``test_append_ticket_body_at_cap`` boundary; the cap
+    check uses the same helper but with ``arg_name="--chunk-file"``.
+    """
+    ticket_id = _create_bee_with_body(cli_runner, isolated_bees_env, body="")
+    file_content = make_body_at_cap()
+    path = tmp_path / "atcap.txt"
+    path.write_text(file_content, encoding="utf-8")
+
+    stdout, exit_code = cli_runner(
+        [
+            "append-ticket-body",
+            "--ticket-id",
+            ticket_id,
+            "--chunk-file",
+            str(path),
+        ]
+    )
+
+    assert exit_code == 0, f"at-cap file append failed: {stdout}"
+    body = _read_body_via_show(cli_runner, ticket_id)
+    assert body == file_content
+
+
+def test_append_ticket_body_chunk_file_empty_file_noop(cli_runner, isolated_bees_env, tmp_path):
+    """An empty ``--chunk-file`` is a no-op: ticket bytes are unchanged.
+
+    LOCKED semantic. Append + empty = concatenation, which is identity.
+    Diverges deliberately from ``update-ticket --body-file <empty>``
+    (which overwrites the body to empty).
+    """
+    ticket_id = _create_bee_with_body(cli_runner, isolated_bees_env, body="hello")
+    snapshot = _ticket_path(isolated_bees_env, ticket_id).read_bytes()
+    path = tmp_path / "empty.txt"
+    path.write_bytes(b"")
+
+    stdout, exit_code = cli_runner(
+        [
+            "append-ticket-body",
+            "--ticket-id",
+            ticket_id,
+            "--chunk-file",
+            str(path),
+        ]
+    )
+
+    assert exit_code == 0, f"empty-file append failed: {stdout}"
+    result = json.loads(stdout)
+    assert result["status"] == "success"
+
+    assert _ticket_path(isolated_bees_env, ticket_id).read_bytes() == snapshot
+
+
+# ---------------------------------------------------------------------------
 # Rejection / error paths
 # ---------------------------------------------------------------------------
 
@@ -166,9 +297,7 @@ def _run_cli_capture_both(argv, capsys):
     return captured.out.strip(), captured.err, exit_code
 
 
-def test_append_ticket_body_oversized_chunk_rejected(
-    cli_runner, isolated_bees_env, capsys
-):
+def test_append_ticket_body_oversized_chunk_rejected(cli_runner, isolated_bees_env, capsys):
     """A chunk one byte over the cap is rejected before any ticket I/O.
 
     SR-10.6 #17: stderr must mention the cap and the subcommand, and the
@@ -200,9 +329,7 @@ def test_append_ticket_body_not_found(cli_runner, isolated_bees_env):
     isolated_bees_env.create_hive("test", "Test")
     isolated_bees_env.write_config()
 
-    stdout, exit_code = cli_runner(
-        ["append-ticket-body", "--ticket-id", "b.zzz", "--chunk", "anything"]
-    )
+    stdout, exit_code = cli_runner(["append-ticket-body", "--ticket-id", "b.zzz", "--chunk", "anything"])
 
     assert exit_code != 0
     result = json.loads(stdout)
@@ -210,14 +337,170 @@ def test_append_ticket_body_not_found(cli_runner, isolated_bees_env):
     assert result["error_type"] == "ticket_not_found"
 
 
-def test_append_ticket_body_missing_required_flag(cli_runner):
-    """argparse should bail out with exit code 2 when --chunk is missing."""
-    stdout, exit_code = cli_runner(
-        ["append-ticket-body", "--ticket-id", "b.zzz"]
-    )
+def test_append_ticket_body_missing_required_chunk_or_chunk_file(cli_runner):
+    """argparse should bail out with exit code 2 when NEITHER ``--chunk`` nor
+    ``--chunk-file`` is supplied (the mutex group is required at group level).
+    """
+    stdout, exit_code = cli_runner(["append-ticket-body", "--ticket-id", "b.zzz"])
     assert exit_code == 2
     result = json.loads(stdout)
     assert result["status"] == "error"
+
+
+# ---------------------------------------------------------------------------
+# Rejection / error paths — Epic 3 / t1.jsz.nb (--chunk-file)
+# ---------------------------------------------------------------------------
+
+
+def test_append_ticket_body_chunk_file_mutex_with_chunk_rejected(cli_runner, isolated_bees_env, tmp_path, capsys):
+    """``--chunk`` and ``--chunk-file`` are mutually exclusive (argparse exit 2).
+
+    The file is written so the failure is unambiguously the mutex (not a
+    missing-file error from ``_read_body_file_arg``).
+    """
+    ticket_id = _create_bee_with_body(cli_runner, isolated_bees_env, body="hello")
+    path = tmp_path / "chunk.txt"
+    path.write_text("file content", encoding="utf-8")
+    snapshot = _ticket_path(isolated_bees_env, ticket_id).read_bytes()
+    capsys.readouterr()
+
+    _stdout, _stderr, exit_code = _run_cli_capture_both(
+        [
+            "append-ticket-body",
+            "--ticket-id",
+            ticket_id,
+            "--chunk",
+            "inline",
+            "--chunk-file",
+            str(path),
+        ],
+        capsys,
+    )
+
+    assert exit_code == 2
+    assert _ticket_path(isolated_bees_env, ticket_id).read_bytes() == snapshot
+
+
+def test_append_ticket_body_chunk_file_mutex_neither_rejected(cli_runner, isolated_bees_env, capsys):
+    """Passing NEITHER ``--chunk`` nor ``--chunk-file`` exits 2 with a message
+    naming both flags. Argparse-default for a required mutex group when
+    nothing in the group is supplied; complement to the "both flags" mutex
+    case above.
+
+    NOTE: ``BeesArgumentParser.error`` (``src/cli.py:52-58``) routes the
+    argparse error message to STDOUT as a JSON ``{"status": "error",
+    "message": ...}`` payload, then exits 2. The substring assertions
+    therefore target stdout, not stderr.
+    """
+    ticket_id = _create_bee_with_body(cli_runner, isolated_bees_env, body="hello")
+    snapshot = _ticket_path(isolated_bees_env, ticket_id).read_bytes()
+    capsys.readouterr()
+
+    stdout, _stderr, exit_code = _run_cli_capture_both(
+        ["append-ticket-body", "--ticket-id", ticket_id, "--hive", "test"],
+        capsys,
+    )
+
+    assert exit_code == 2
+    # Loose substring check across Python versions — argparse wording may
+    # change but both flag names should always appear in the error message.
+    assert "--chunk" in stdout
+    assert "--chunk-file" in stdout
+    assert _ticket_path(isolated_bees_env, ticket_id).read_bytes() == snapshot
+
+
+def test_append_ticket_body_chunk_file_missing_file_rejected(cli_runner, isolated_bees_env, tmp_path, capsys):
+    """A missing ``--chunk-file`` path names both the path and the flag.
+
+    Helper-level error (``_read_body_file_arg``); ticket bytes unchanged.
+    """
+    ticket_id = _create_bee_with_body(cli_runner, isolated_bees_env, body="hello")
+    snapshot = _ticket_path(isolated_bees_env, ticket_id).read_bytes()
+    capsys.readouterr()
+
+    missing = tmp_path / "does_not_exist.txt"
+    _stdout, stderr, exit_code = _run_cli_capture_both(
+        [
+            "append-ticket-body",
+            "--ticket-id",
+            ticket_id,
+            "--chunk-file",
+            str(missing),
+        ],
+        capsys,
+    )
+
+    assert exit_code != 0
+    assert str(missing) in stderr
+    assert "--chunk-file" in stderr
+    assert _ticket_path(isolated_bees_env, ticket_id).read_bytes() == snapshot
+
+
+def test_append_ticket_body_chunk_file_decode_error_rejected(cli_runner, isolated_bees_env, tmp_path, capsys):
+    """Invalid UTF-8 in ``--chunk-file`` exits non-zero with a UTF-8 diagnostic.
+
+    Helper-level error (``_read_body_file_arg``); ticket bytes unchanged.
+    """
+    ticket_id = _create_bee_with_body(cli_runner, isolated_bees_env, body="hello")
+    snapshot = _ticket_path(isolated_bees_env, ticket_id).read_bytes()
+    capsys.readouterr()
+
+    path = tmp_path / "bad_utf8.bin"
+    # 0xff is never a valid UTF-8 start byte.
+    path.write_bytes(b"\xff\xfe")
+
+    _stdout, stderr, exit_code = _run_cli_capture_both(
+        [
+            "append-ticket-body",
+            "--ticket-id",
+            ticket_id,
+            "--chunk-file",
+            str(path),
+        ],
+        capsys,
+    )
+
+    assert exit_code != 0
+    assert "UTF-8" in stderr
+    assert "decode" in stderr.lower()
+    assert _ticket_path(isolated_bees_env, ticket_id).read_bytes() == snapshot
+
+
+def test_append_ticket_body_chunk_file_oversized_rejected(cli_runner, isolated_bees_env, tmp_path, capsys):
+    """An oversized ``--chunk-file`` is rejected with stderr naming the cap,
+    the subcommand, and ``--chunk-file`` as a standalone token.
+
+    The cap-check ``arg_name`` parameterization is what surfaces
+    ``--chunk-file`` (rather than ``--chunk``) in the error. Asserting the
+    flag as a standalone token (split by whitespace) prevents accidental
+    pass-through of a loose substring match (the existing
+    ``test_append_ticket_body_oversized_chunk_rejected`` exercises the
+    ``--chunk`` path and remains unchanged).
+    """
+    ticket_id = _create_bee_with_body(cli_runner, isolated_bees_env, body="hello")
+    snapshot = _ticket_path(isolated_bees_env, ticket_id).read_bytes()
+    capsys.readouterr()
+
+    path = tmp_path / "oversized.txt"
+    path.write_text(make_body_over_cap(), encoding="utf-8")
+
+    _stdout, stderr, exit_code = _run_cli_capture_both(
+        [
+            "append-ticket-body",
+            "--ticket-id",
+            ticket_id,
+            "--chunk-file",
+            str(path),
+        ],
+        capsys,
+    )
+
+    assert exit_code != 0
+    assert "10000" in stderr
+    assert str(BODY_MAX_LENGTH + 1) in stderr
+    assert "append-ticket-body" in stderr
+    assert "--chunk-file" in stderr.split()
+    assert _ticket_path(isolated_bees_env, ticket_id).read_bytes() == snapshot
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_body_cap_on_create_update.py
+++ b/tests/test_cli_body_cap_on_create_update.py
@@ -11,19 +11,28 @@ Covers Epic 5 of the chunked-ticket-body-API plan (Bee b.87r):
 - ``--body`` help text on both subcommands names ``append-ticket-body`` and
   ``10000`` so Claude can pick the right tool from the help signal.
 
+Also covers Epic 1 / Task 2 of the ``--body-file`` / ``--chunk-file`` feature
+(Bee ``b.jsz``, plan ``t1.jsz.de``):
+- ``create-ticket --body-file PATH`` reads UTF-8 file contents (or stdin when
+  ``PATH == "-"``), routes them through ``_read_body_file_arg`` and the same
+  ``_reject_oversized_body_cli`` cap check as ``--body`` (parameterized to
+  name ``--body-file`` in the rejection message).
+- ``--body`` and ``--body-file`` are mutually exclusive (argparse mutex group).
+- File-surface error paths (missing file, UTF-8 decode error, oversized file)
+  exit non-zero, write a stderr diagnostic, and write no ticket files.
+
 This file lives in its own module (rather than being added to ``tests/test_cli.py``
 which has unrelated pre-existing collection errors, or to Epic 4's
 ``tests/test_cli_append_ticket_body.py`` which is scoped to its own subcommand) so
 each Epic of the plan owns a self-contained test surface.
 """
 
+import io
 import json
-
-import pytest
 
 from src.constants import BODY_MAX_LENGTH
 from src.paths import compute_ticket_path
-from tests.helpers import run_cli_capture_both
+from tests.helpers import make_body_at_cap, make_body_over_cap, run_cli_capture_both
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -155,9 +164,7 @@ def test_update_ticket_body_at_cap_succeeds(cli_runner, isolated_bees_env):
     ticket_id = _create_bee(cli_runner, isolated_bees_env, body="seed")
     new_body = "u" * BODY_MAX_LENGTH
 
-    stdout, exit_code = cli_runner(
-        ["update-ticket", "--ids", ticket_id, "--body", new_body]
-    )
+    stdout, exit_code = cli_runner(["update-ticket", "--ids", ticket_id, "--body", new_body])
     assert exit_code == 0, f"update at cap failed: {stdout}"
     assert _read_body_via_show(cli_runner, ticket_id) == new_body
 
@@ -170,9 +177,7 @@ def test_update_ticket_without_body_does_not_fire_helper(cli_runner, isolated_be
     """
     ticket_id = _create_bee(cli_runner, isolated_bees_env, body="seed")
 
-    stdout, exit_code = cli_runner(
-        ["update-ticket", "--ids", ticket_id, "--add-tags", '["x"]']
-    )
+    stdout, exit_code = cli_runner(["update-ticket", "--ids", ticket_id, "--add-tags", '["x"]'])
     assert exit_code == 0, f"update without --body failed: {stdout}"
 
     # Body is unchanged.
@@ -216,3 +221,230 @@ def test_update_ticket_help_text_mentions_append_subcommand_and_cap(cli_runner):
     flat = _normalize_help(stdout)
     assert "append-ticket-body" in flat
     assert "10000" in flat
+
+
+# ---------------------------------------------------------------------------
+# create-ticket --body-file happy paths (Epic 1 / t1.jsz.de)
+# ---------------------------------------------------------------------------
+
+
+def _create_bee_with_body_file(cli_runner, isolated_bees_env, body_file_arg: str) -> str:
+    """Run ``create-ticket --body-file <body_file_arg>`` and return the ticket id."""
+    _setup_test_hive(isolated_bees_env)
+    stdout, exit_code = cli_runner(
+        [
+            "create-ticket",
+            "--ticket-type",
+            "bee",
+            "--title",
+            "Cap Target",
+            "--hive",
+            "test",
+            "--body-file",
+            body_file_arg,
+        ]
+    )
+    assert exit_code == 0, f"create-ticket --body-file failed: {stdout}"
+    return json.loads(stdout)["ticket_id"]
+
+
+def test_create_ticket_body_file_happy_path_file(cli_runner, isolated_bees_env, tmp_path):
+    """A UTF-8 file with non-ASCII content round-trips through --body-file."""
+    body = "hello ☃ world"  # snowman exercises non-ASCII UTF-8 decoding.
+    path = tmp_path / "input.md"
+    path.write_text(body, encoding="utf-8")
+
+    ticket_id = _create_bee_with_body_file(cli_runner, isolated_bees_env, str(path))
+
+    assert _read_body_via_show(cli_runner, ticket_id) == body
+
+
+def test_create_ticket_body_file_stdin_happy_path(cli_runner, isolated_bees_env, monkeypatch):
+    """``--body-file -`` reads from sys.stdin via in-process patching.
+
+    ``cli_runner`` invokes ``src.cli.main()`` IN-PROCESS (see
+    ``tests/conftest.py:618-637``); it does NOT spawn a subprocess. Stdin
+    must be patched on the live ``sys`` module — ``subprocess.run(input=...)``
+    would never reach the in-process call.
+    """
+    body = "from-stdin\nbody é"
+    monkeypatch.setattr("sys.stdin", io.StringIO(body))
+
+    ticket_id = _create_bee_with_body_file(cli_runner, isolated_bees_env, "-")
+
+    assert _read_body_via_show(cli_runner, ticket_id) == body
+
+
+def test_create_ticket_body_file_at_cap_succeeds(cli_runner, isolated_bees_env, tmp_path):
+    """A file with exactly BODY_MAX_LENGTH characters is accepted via --body-file."""
+    body = make_body_at_cap()
+    path = tmp_path / "atcap.md"
+    path.write_text(body, encoding="utf-8")
+
+    ticket_id = _create_bee_with_body_file(cli_runner, isolated_bees_env, str(path))
+
+    assert _read_body_via_show(cli_runner, ticket_id) == body
+
+
+def test_create_ticket_body_file_empty_succeeds(cli_runner, isolated_bees_env, tmp_path):
+    """An empty --body-file produces a ticket with an empty body.
+
+    Verifies the helper's empty-string return propagates through the cap
+    check (which permits empty bodies) and the ticket persists.
+    """
+    path = tmp_path / "empty.md"
+    path.write_bytes(b"")
+
+    ticket_id = _create_bee_with_body_file(cli_runner, isolated_bees_env, str(path))
+
+    assert _read_body_via_show(cli_runner, ticket_id) == ""
+
+
+# ---------------------------------------------------------------------------
+# create-ticket --body-file error paths (Epic 1 / t1.jsz.de)
+# ---------------------------------------------------------------------------
+
+
+def test_create_ticket_body_file_mutex_with_body_rejected(cli_runner, isolated_bees_env, tmp_path, capsys):
+    """``--body`` and ``--body-file`` are mutually exclusive (argparse default)."""
+    _setup_test_hive(isolated_bees_env)
+    capsys.readouterr()
+
+    # File must exist so the failure is unambiguously the mutex, not a
+    # missing-file error from ``_read_body_file_arg``.
+    path = tmp_path / "input.md"
+    path.write_text("file content", encoding="utf-8")
+
+    _stdout, _stderr, exit_code = run_cli_capture_both(
+        [
+            "create-ticket",
+            "--ticket-type",
+            "bee",
+            "--title",
+            "Should Not Exist",
+            "--hive",
+            "test",
+            "--body",
+            "inline content",
+            "--body-file",
+            str(path),
+        ],
+        capsys,
+    )
+
+    # argparse mutex violations exit with code 2.
+    assert exit_code == 2
+
+    hive_dir = isolated_bees_env.base_path / "test"
+    md_files = list(hive_dir.rglob("*.md"))
+    assert md_files == [], f"unexpected ticket files written: {md_files}"
+
+
+def test_create_ticket_body_file_missing_file_rejected(cli_runner, isolated_bees_env, tmp_path, capsys):
+    """A missing --body-file path names both the path and the flag in stderr."""
+    _setup_test_hive(isolated_bees_env)
+    capsys.readouterr()
+
+    missing = tmp_path / "does_not_exist.md"
+
+    _stdout, stderr, exit_code = run_cli_capture_both(
+        [
+            "create-ticket",
+            "--ticket-type",
+            "bee",
+            "--title",
+            "Should Not Exist",
+            "--hive",
+            "test",
+            "--body-file",
+            str(missing),
+        ],
+        capsys,
+    )
+
+    assert exit_code != 0
+    assert str(missing) in stderr
+    assert "--body-file" in stderr
+
+    hive_dir = isolated_bees_env.base_path / "test"
+    md_files = list(hive_dir.rglob("*.md"))
+    assert md_files == [], f"unexpected ticket files written: {md_files}"
+
+
+def test_create_ticket_body_file_decode_error_rejected(cli_runner, isolated_bees_env, tmp_path, capsys):
+    """Invalid UTF-8 in --body-file exits non-zero with a UTF-8/decoding diagnostic."""
+    _setup_test_hive(isolated_bees_env)
+    capsys.readouterr()
+
+    path = tmp_path / "bad_utf8.bin"
+    # 0xff is never a valid UTF-8 start byte.
+    path.write_bytes(b"\xff\xfe")
+
+    _stdout, stderr, exit_code = run_cli_capture_both(
+        [
+            "create-ticket",
+            "--ticket-type",
+            "bee",
+            "--title",
+            "Should Not Exist",
+            "--hive",
+            "test",
+            "--body-file",
+            str(path),
+        ],
+        capsys,
+    )
+
+    assert exit_code != 0
+    assert "UTF-8" in stderr
+    assert "decode" in stderr.lower()
+    assert "--body-file" in stderr
+
+    hive_dir = isolated_bees_env.base_path / "test"
+    md_files = list(hive_dir.rglob("*.md"))
+    assert md_files == [], f"unexpected ticket files written: {md_files}"
+
+
+def test_create_ticket_body_file_oversized_rejected(cli_runner, isolated_bees_env, tmp_path, capsys):
+    """An oversized file rejection names ``--body-file`` (not just ``--body``).
+
+    The cap-check ``arg_name`` parameterization is what surfaces ``--body-file``
+    in the error. Since ``--body-file`` contains the substring ``--body``, a
+    loose ``"--body" in stderr`` would also pass even on the un-parameterized
+    code path. We therefore pin specifically on ``--body-file`` as a
+    whitespace-bounded token to verify the parameterization fired.
+    """
+    _setup_test_hive(isolated_bees_env)
+    capsys.readouterr()
+
+    path = tmp_path / "oversized.md"
+    path.write_text(make_body_over_cap(), encoding="utf-8")
+
+    _stdout, stderr, exit_code = run_cli_capture_both(
+        [
+            "create-ticket",
+            "--ticket-type",
+            "bee",
+            "--title",
+            "Should Not Exist",
+            "--hive",
+            "test",
+            "--body-file",
+            str(path),
+        ],
+        capsys,
+    )
+
+    assert exit_code != 0
+    assert "10000" in stderr
+    assert str(BODY_MAX_LENGTH + 1) in stderr
+    assert "append-ticket-body" in stderr
+
+    # ``--body-file`` as a standalone whitespace-bounded token. Splitting
+    # on any whitespace is robust to argparse's wrapping/normalization.
+    tokens = stderr.split()
+    assert "--body-file" in tokens, f"expected '--body-file' as a standalone token in stderr; got tokens={tokens!r}"
+
+    hive_dir = isolated_bees_env.base_path / "test"
+    md_files = list(hive_dir.rglob("*.md"))
+    assert md_files == [], f"unexpected ticket files written: {md_files}"

--- a/tests/test_cli_body_cap_on_create_update.py
+++ b/tests/test_cli_body_cap_on_create_update.py
@@ -239,6 +239,26 @@ def test_update_ticket_help_text_mentions_append_subcommand_and_cap(cli_runner):
     assert "10000" in flat
 
 
+def test_create_ticket_help_text_mentions_body_file_stdin_and_cap(cli_runner):
+    """`bees create-ticket --help` advertises --body-file with stdin and the cap (AC #8)."""
+    stdout, exit_code = cli_runner(["create-ticket", "--help"])
+    assert exit_code == 0
+    flat = _normalize_help(stdout)
+    assert "--body-file" in flat
+    assert "'-'" in flat
+    assert "10000" in flat
+
+
+def test_update_ticket_help_text_mentions_body_file_stdin_and_cap(cli_runner):
+    """`bees update-ticket --help` advertises --body-file with stdin and the cap (AC #8)."""
+    stdout, exit_code = cli_runner(["update-ticket", "--help"])
+    assert exit_code == 0
+    flat = _normalize_help(stdout)
+    assert "--body-file" in flat
+    assert "'-'" in flat
+    assert "10000" in flat
+
+
 # ---------------------------------------------------------------------------
 # create-ticket --body-file happy paths (Epic 1 / t1.jsz.de)
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_body_cap_on_create_update.py
+++ b/tests/test_cli_body_cap_on_create_update.py
@@ -21,6 +21,22 @@ Also covers Epic 1 / Task 2 of the ``--body-file`` / ``--chunk-file`` feature
 - File-surface error paths (missing file, UTF-8 decode error, oversized file)
   exit non-zero, write a stderr diagnostic, and write no ticket files.
 
+Also covers Epic 2 of the same feature (Bee ``b.jsz``, plan ``t1.jsz.sh``):
+- ``update-ticket --body-file PATH`` mirrors create-ticket's wiring on the
+  update surface: UTF-8 file contents (or stdin when ``PATH == "-"``) are
+  read by ``_read_body_file_arg`` and routed through the parameterized
+  ``_reject_oversized_body_cli`` cap check (which names ``--body-file`` on
+  this surface).
+- ``--body`` and ``--body-file`` are mutually exclusive on update-ticket
+  (argparse mutex group).
+- Every error path (mutex, missing file, UTF-8 decode error, oversized file)
+  exits non-zero AND leaves the target ticket's on-disk ``.md`` byte-identical
+  to its pre-call snapshot.
+- The ``args.body is _UNSET`` sentinel-skip path (no ``--body`` and no
+  ``--body-file``) survives the parser restructure into a mutex group: see
+  the load-bearing ``test_update_ticket_without_body_does_not_fire_helper``
+  regression guard below.
+
 This file lives in its own module (rather than being added to ``tests/test_cli.py``
 which has unrelated pre-existing collection errors, or to Epic 4's
 ``tests/test_cli_append_ticket_body.py`` which is scoped to its own subcommand) so
@@ -448,3 +464,190 @@ def test_create_ticket_body_file_oversized_rejected(cli_runner, isolated_bees_en
     hive_dir = isolated_bees_env.base_path / "test"
     md_files = list(hive_dir.rglob("*.md"))
     assert md_files == [], f"unexpected ticket files written: {md_files}"
+
+
+# ---------------------------------------------------------------------------
+# update-ticket --body-file happy paths (Epic 2 / t1.jsz.sh)
+# ---------------------------------------------------------------------------
+
+
+def test_update_ticket_body_file_happy_path_file(cli_runner, isolated_bees_env, tmp_path):
+    """A UTF-8 file with non-ASCII content round-trips through update --body-file."""
+    ticket_id = _create_bee(cli_runner, isolated_bees_env, body="seed")
+    new_body = "updated ☃ body"  # snowman exercises non-ASCII UTF-8 decoding.
+    path = tmp_path / "input.md"
+    path.write_text(new_body, encoding="utf-8")
+
+    stdout, exit_code = cli_runner(["update-ticket", "--ids", ticket_id, "--body-file", str(path)])
+    assert exit_code == 0, f"update --body-file failed: {stdout}"
+    assert _read_body_via_show(cli_runner, ticket_id) == new_body
+
+
+def test_update_ticket_body_file_stdin_happy_path(cli_runner, isolated_bees_env, monkeypatch):
+    """``update-ticket --body-file -`` reads from sys.stdin via in-process patching.
+
+    ``cli_runner`` invokes ``src.cli.main()`` IN-PROCESS (see
+    ``tests/conftest.py:618-637``); it does NOT spawn a subprocess. Stdin
+    must be patched on the live ``sys`` module — ``subprocess.run(input=...)``
+    would never reach the in-process call.
+    """
+    ticket_id = _create_bee(cli_runner, isolated_bees_env, body="seed")
+    new_body = "from-stdin\nupdate é"
+    monkeypatch.setattr("sys.stdin", io.StringIO(new_body))
+
+    stdout, exit_code = cli_runner(["update-ticket", "--ids", ticket_id, "--body-file", "-"])
+    assert exit_code == 0, f"update --body-file - failed: {stdout}"
+    assert _read_body_via_show(cli_runner, ticket_id) == new_body
+
+
+def test_update_ticket_body_file_at_cap_succeeds(cli_runner, isolated_bees_env, tmp_path):
+    """A file with exactly BODY_MAX_LENGTH characters is accepted via update --body-file."""
+    ticket_id = _create_bee(cli_runner, isolated_bees_env, body="seed")
+    new_body = make_body_at_cap()
+    path = tmp_path / "atcap.md"
+    path.write_text(new_body, encoding="utf-8")
+
+    stdout, exit_code = cli_runner(["update-ticket", "--ids", ticket_id, "--body-file", str(path)])
+    assert exit_code == 0, f"update --body-file at cap failed: {stdout}"
+    assert _read_body_via_show(cli_runner, ticket_id) == new_body
+
+
+def test_update_ticket_body_file_empty_succeeds(cli_runner, isolated_bees_env, tmp_path):
+    """An empty --body-file overwrites the target body to the empty string.
+
+    LOCKED SEMANTIC: empty file is an *explicit overwrite to empty*, NOT a
+    no-op. The helper returns ``""``; the handler then sets ``args.body =
+    ""`` and (since ``"" is not _UNSET`` and ``"" is not None``) writes
+    ``body=""`` into the update kwargs. This mirrors ``--body ""`` exactly.
+    """
+    ticket_id = _create_bee(cli_runner, isolated_bees_env, body="seed")
+    # Sanity: pre-call body is "seed" (so the assertion below is a real change).
+    assert _read_body_via_show(cli_runner, ticket_id) == "seed"
+
+    path = tmp_path / "empty.md"
+    path.write_bytes(b"")
+
+    stdout, exit_code = cli_runner(["update-ticket", "--ids", ticket_id, "--body-file", str(path)])
+    assert exit_code == 0, f"update --body-file empty failed: {stdout}"
+    assert _read_body_via_show(cli_runner, ticket_id) == ""
+
+
+# ---------------------------------------------------------------------------
+# update-ticket --body-file error paths (Epic 2 / t1.jsz.sh)
+# ---------------------------------------------------------------------------
+
+
+def test_update_ticket_body_file_mutex_with_body_rejected(cli_runner, isolated_bees_env, tmp_path, capsys):
+    """``--body`` and ``--body-file`` are mutually exclusive on update-ticket.
+
+    Argparse mutex violations exit with code 2 specifically (distinct from
+    the ``exit_code != 0`` shape of the missing/decode/oversized cases).
+    The on-disk ticket must be byte-identical to its pre-call snapshot.
+    """
+    ticket_id = _create_bee(cli_runner, isolated_bees_env, body="seed")
+    path_obj = _ticket_path(isolated_bees_env, ticket_id)
+    snapshot = path_obj.read_bytes()
+    capsys.readouterr()
+
+    # File MUST exist so the failure is unambiguously the mutex, not a
+    # missing-file error from ``_read_body_file_arg``.
+    body_file = tmp_path / "input.md"
+    body_file.write_text("file content", encoding="utf-8")
+
+    _stdout, _stderr, exit_code = run_cli_capture_both(
+        [
+            "update-ticket",
+            "--ids",
+            ticket_id,
+            "--body",
+            "inline content",
+            "--body-file",
+            str(body_file),
+        ],
+        capsys,
+    )
+
+    assert exit_code == 2
+    assert path_obj.read_bytes() == snapshot
+
+
+def _seed_and_snapshot(cli_runner, isolated_bees_env, capsys):
+    """Create a seeded ticket, snapshot its on-disk bytes, and drain capsys.
+
+    Shared setup for the three byte-identity error tests (missing / decode /
+    oversized). Returns ``(ticket_id, on_disk_path, snapshot_bytes)``.
+    """
+    ticket_id = _create_bee(cli_runner, isolated_bees_env, body="seed")
+    on_disk = _ticket_path(isolated_bees_env, ticket_id)
+    snapshot = on_disk.read_bytes()
+    capsys.readouterr()
+    return ticket_id, on_disk, snapshot
+
+
+def test_update_ticket_body_file_missing_file_rejected(cli_runner, isolated_bees_env, tmp_path, capsys):
+    """A missing --body-file path names both the path and the flag in stderr."""
+    ticket_id, on_disk, snapshot = _seed_and_snapshot(cli_runner, isolated_bees_env, capsys)
+
+    missing = tmp_path / "does_not_exist.md"
+
+    _stdout, stderr, exit_code = run_cli_capture_both(
+        ["update-ticket", "--ids", ticket_id, "--body-file", str(missing)],
+        capsys,
+    )
+
+    assert exit_code != 0
+    assert str(missing) in stderr
+    assert "--body-file" in stderr
+
+    assert on_disk.read_bytes() == snapshot
+
+
+def test_update_ticket_body_file_decode_error_rejected(cli_runner, isolated_bees_env, tmp_path, capsys):
+    """Invalid UTF-8 in update --body-file exits non-zero with a decode diagnostic."""
+    ticket_id, on_disk, snapshot = _seed_and_snapshot(cli_runner, isolated_bees_env, capsys)
+
+    bad = tmp_path / "bad_utf8.bin"
+    # 0xff is never a valid UTF-8 start byte.
+    bad.write_bytes(b"\xff\xfe")
+
+    _stdout, stderr, exit_code = run_cli_capture_both(
+        ["update-ticket", "--ids", ticket_id, "--body-file", str(bad)],
+        capsys,
+    )
+
+    assert exit_code != 0
+    assert "UTF-8" in stderr
+    assert "decode" in stderr.lower()
+    assert "--body-file" in stderr
+
+    assert on_disk.read_bytes() == snapshot
+
+
+def test_update_ticket_body_file_oversized_rejected(cli_runner, isolated_bees_env, tmp_path, capsys):
+    """Oversized update --body-file pins ``--body-file`` as a standalone token in stderr.
+
+    Because ``--body-file`` contains the substring ``--body``, a loose
+    ``"--body" in stderr`` would also pass even on the un-parameterized
+    code path. We pin specifically on ``--body-file`` as a whitespace-bounded
+    token to verify the cap-check arg_name parameterization actually flipped
+    from ``"--body"`` to ``"--body-file"`` on this surface.
+    """
+    ticket_id, on_disk, snapshot = _seed_and_snapshot(cli_runner, isolated_bees_env, capsys)
+
+    big = tmp_path / "oversized.md"
+    big.write_text(make_body_over_cap(), encoding="utf-8")
+
+    _stdout, stderr, exit_code = run_cli_capture_both(
+        ["update-ticket", "--ids", ticket_id, "--body-file", str(big)],
+        capsys,
+    )
+
+    assert exit_code != 0
+    assert "10000" in stderr
+    assert str(BODY_MAX_LENGTH + 1) in stderr
+    assert "append-ticket-body" in stderr
+
+    tokens = stderr.split()
+    assert "--body-file" in tokens, f"expected '--body-file' as a standalone token in stderr; got tokens={tokens!r}"
+
+    assert on_disk.read_bytes() == snapshot

--- a/tests/test_cli_read_body_file_arg.py
+++ b/tests/test_cli_read_body_file_arg.py
@@ -1,0 +1,130 @@
+"""Direct unit tests for the ``_read_body_file_arg`` CLI helper.
+
+Covers Epic 1 / Task 1 of the ``--body-file`` / ``--chunk-file`` feature
+(Bee ``b.jsz``). The helper reads body text for a CLI flag from either a
+real file path or, when ``path == "-"``, ``sys.stdin``. On UTF-8 decode
+errors and I/O errors it writes a single-line ``Error:`` message to
+stderr and exits non-zero; on success it returns the decoded contents.
+
+These tests exercise the helper in isolation using ``tmp_path`` for real
+files and ``monkeypatch.setattr("sys.stdin", ...)`` for the stdin path
+— no mocking of ``open``, ``Path.read_text``, or ``sys.stdin`` at the
+module level. They mirror the ``_reject_oversized_body_cli`` unit-test
+pattern in ``tests/test_cli_append_ticket_body.py``.
+"""
+
+import io
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Happy paths
+# ---------------------------------------------------------------------------
+
+
+def test_read_body_file_arg_returns_utf8_file_contents(tmp_path, capsys):
+    from src.cli import _read_body_file_arg
+
+    # Non-ASCII codepoint to confirm UTF-8 decoding (not latin-1 fallback).
+    body = "hello ☃ world"  # snowman
+    path = tmp_path / "body.txt"
+    path.write_text(body, encoding="utf-8")
+
+    result = _read_body_file_arg("--body-file", str(path))
+
+    assert result == body
+    assert capsys.readouterr().err == ""
+
+
+def test_read_body_file_arg_reads_stdin_when_path_is_dash(monkeypatch, capsys):
+    from src.cli import _read_body_file_arg
+
+    body = "stdin body é"  # latin small e with acute
+    monkeypatch.setattr("sys.stdin", io.StringIO(body))
+
+    result = _read_body_file_arg("--body-file", "-")
+
+    assert result == body
+    assert capsys.readouterr().err == ""
+
+
+def test_read_body_file_arg_returns_empty_string_for_empty_file(tmp_path, capsys):
+    from src.cli import _read_body_file_arg
+
+    path = tmp_path / "empty.txt"
+    path.write_bytes(b"")
+
+    result = _read_body_file_arg("--body-file", str(path))
+
+    assert result == ""
+    assert capsys.readouterr().err == ""
+
+
+# ---------------------------------------------------------------------------
+# Error paths (parametrized: same SystemExit + stderr-substring shape)
+# ---------------------------------------------------------------------------
+
+
+def _setup_missing_file(tmp_path):
+    return str(tmp_path / "does_not_exist.txt"), ["file not found"]
+
+
+def _setup_decode_error(tmp_path):
+    path = tmp_path / "bad_utf8.bin"
+    # 0xff is never a valid UTF-8 start byte.
+    path.write_bytes(b"\xff\xfe\xfd")
+    return str(path), ["could not decode", "UTF-8"]
+
+
+def _setup_directory_as_path(tmp_path):
+    # Reading a directory raises OSError (IsADirectoryError on POSIX),
+    # which the helper handles via its OSError branch. Preferred over
+    # chmod 000 since it works under root and on macOS/Linux CI alike.
+    return str(tmp_path), ["could not read"]
+
+
+@pytest.mark.parametrize(
+    "setup,arg_name",
+    [
+        pytest.param(_setup_missing_file, "--body-file", id="missing_file"),
+        pytest.param(_setup_decode_error, "--chunk-file", id="utf8_decode_error"),
+        pytest.param(_setup_directory_as_path, "--body-file", id="directory_as_path"),
+    ],
+)
+def test_read_body_file_arg_error_paths_exit_nonzero(setup, arg_name, tmp_path, capsys):
+    from src.cli import _read_body_file_arg
+
+    path, expected_substrs = setup(tmp_path)
+
+    with pytest.raises(SystemExit) as excinfo:
+        _read_body_file_arg(arg_name, path)
+
+    assert excinfo.value.code != 0
+    err = capsys.readouterr().err
+    assert arg_name in err
+    assert path in err
+    for substr in expected_substrs:
+        assert substr in err
+
+
+def test_read_body_file_arg_stdin_utf8_decode_error(monkeypatch, capsys):
+    # Real CLI sys.stdin is a TextIOWrapper(errors="strict"); piping invalid
+    # UTF-8 bytes raises UnicodeDecodeError from .read(). Setup differs from
+    # the file-error parametrize (stub object vs. tmp_path), so kept separate.
+    from src.cli import _read_body_file_arg
+
+    class _BadStdin:
+        def read(self):
+            raise UnicodeDecodeError("utf-8", b"\xff", 0, 1, "invalid start byte")
+
+    monkeypatch.setattr("sys.stdin", _BadStdin())
+
+    with pytest.raises(SystemExit) as excinfo:
+        _read_body_file_arg("--body-file", "-")
+
+    assert excinfo.value.code != 0
+    err = capsys.readouterr().err
+    assert "--body-file" in err
+    assert "could not decode" in err
+    assert "stdin" in err
+    assert "UTF-8" in err


### PR DESCRIPTION
Closes #2

## Summary

Adds `--body-file PATH` to `create-ticket` and `update-ticket`, and `--chunk-file PATH` to `append-ticket-body`. Each new flag is mutually exclusive with its existing string counterpart (`--body` / `--chunk`); path `-` reads from stdin; UTF-8 only; same 10000-character cap. Issue #2 covers the motivation in detail — `$(cat ...)` shell substitution triggers permission-prompt friction in agentic harnesses (Claude Code allowlists treat command substitution as opaque) and is fragile to quoting when the body contains `'`, `"`, `$`, or backticks. The new flag eliminates both.

## New flags

| Command | Existing | New |
|---|---|---|
| `create-ticket` | `--body BODY` | `--body-file PATH` |
| `update-ticket` | `--body BODY` | `--body-file PATH` |
| `append-ticket-body` | `--chunk TEXT` | `--chunk-file PATH` |

`--body-file` / `--chunk-file` accept a UTF-8 file path or `-` for stdin. The two flags in each pair are wired into a single `argparse.add_mutually_exclusive_group()` at the parser level.

## Behavior details

- **Mutex enforcement at parser**: passing both `--body` and `--body-file` (or both `--chunk` and `--chunk-file`) → argparse mutex error, exit 2, no ticket I/O.
- **Empty file**:
  - `create-ticket --body-file <empty>` → ticket body is `""` (matches `--body ""`).
  - `update-ticket --body-file <empty>` → overwrites body to `""` (locked semantic, mirrors `--body ""`).
  - `append-ticket-body --chunk-file <empty>` → no-op (locked semantic, mirrors `--chunk ""`); appending `""` is mathematically a no-op.
- **Required-mutex on append-ticket-body**: `--chunk` was previously `required=True` standalone; this PR moves the requirement onto the mutex group, so the user-visible "must supply chunk text" behavior is preserved (now: "one of `--chunk` or `--chunk-file` is required").
- **Errors** (file-not-found / OSError / UTF-8 decode error / oversized): exit 1 with a single-line `Error:` stderr message naming the offending flag (e.g. `--body-file`) and the path. Ticket files unchanged on every error path (verified by byte-identity assertions in tests).
- **Cap-rejection**: existing `_reject_oversized_body_cli` is parameterized to name `--body-file` / `--chunk-file` when the file flag was used, falling back to `--body` / `--chunk` for the inline path. Existing inline-flag oversized error messages are unchanged.

## Implementation

A single shared helper `_read_body_file_arg(arg_name: str, path: str) -> str` lives in `src/cli.py` and is called by all three handlers. The helper handles the `-` stdin sentinel via `sys.stdin.read()` (monkeypatchable by tests), opens files in binary mode and explicitly `.decode("utf-8")` to keep the decode error path well-typed, and never length-checks (callers continue to invoke `_reject_oversized_body_cli`).

## Tests

- `tests/test_cli_read_body_file_arg.py` (new) — 7 unit tests for the helper covering all error branches plus three happy paths. Real fs via `tmp_path`; `sys.stdin` monkeypatched in-place.
- `tests/test_cli_body_cap_on_create_update.py` — extended with 8 `create-ticket --body-file` integration tests plus 8 `update-ticket --body-file` integration tests. Every error-path test captures a byte-snapshot of the ticket file before the failing CLI call and asserts byte-identity afterward (no partial-write / leak-on-error). The oversized-via-file tests pin `"--body-file"` as a standalone token in stderr to verify the cap-check parameterization.
- `tests/test_cli_append_ticket_body.py` — extended with 9 `--chunk-file` integration tests covering happy file, happy stdin, at-cap boundary, empty-file no-op, mutex-both, mutex-neither, missing file, decode error, oversized via file. The existing `test_append_ticket_body_missing_required_chunk` was renamed in-place to `test_append_ticket_body_missing_required_chunk_or_chunk_file` (preserves git blame; assertions unchanged) since the requirement moved from flag-level to mutex-group-level.

All existing `--body` / `--chunk` regression tests pass unchanged.

## Docs

- `docs/PRD.md` §22.3 (Complete Command List) and §17 (per-command bees subcommand reference) brought in line with the post-PR CLI surface for the three commands. Drift fixes for `--description` → `--body` and `--ticket-id` → `--ids` in those rows/blocks are included because the new flag's mutex partner has to be named correctly. Drift on other commands' rows/blocks is intentionally left alone (Plan §Out of scope).
- `docs/advanced-usage.md` — the `## Ticket Operations` example block gets three minimal copy-pasteable examples (`--body-file ./writeup.md`, `--body-file -` for stdin, `--chunk-file ./next-chunk.md`); the chunked-workflow paragraph is extended with one sentence covering mutex behavior, stdin via `-`, and "cap applies regardless of input source."

## Out of scope

Per the original issue: no MCP-side changes (no shell-quoting problem there), no `--egg-file` for `--egg JSON`, no curl-style `--body @PATH` spelling, no cap change, no binary-file support (UTF-8 only), no comprehensive PRD accuracy pass for unrelated commands.
